### PR TITLE
Add support for plugin images

### DIFF
--- a/jprm/__init__.py
+++ b/jprm/__init__.py
@@ -538,7 +538,7 @@ def generate_plugin_manifest(filename, repo_url='', meta=None, md5=None):
         )
 
         if "imageUrl" in meta:
-            logger.warning("Image URL `{}` is getting overwritten by `{}` due to presence of `image`.", meta['imageUrl'], manifest['imageUrl'])
+            logger.warning("Image URL `{}` is getting overwritten by `{}` due to presence of `image`.".format(meta['imageUrl'], manifest['imageUrl']))
 
     elif "imageUrl" not in meta:
         logger.warning("Neither image nor imageUrl is specified.")


### PR DESCRIPTION
- jellyfin/jellyfin-ux#43 Issue tracking progress creating images for the official plugins.
- jellyfin/jellyfin-ux#44 Pull-request containing the images.

Each plugin needs an update to their own repo to do at least one of:
1. Add the `imageUrl` key pointing to a web URL containing the image
2. Add a file named `image.png` next to `build.yaml` in the repo
3. Add a image file somewhere in the repo, and add the `image` key pointing to this relative path
4. The file `image.png` and the `image` key pointing to this file (This is the preferred way)

If both the `imageUrl` and `image` (or the `image.png` file) keys are provided, a warning will be thrown, and the `imageUrl` key will be over-written uppon adding the zip to the repo.