### PR TITLE
GH Composite Action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,9 +53,12 @@ runs:
       shell: bash
       run: |-
         echo "::group::Building and Packaging"
+
         if [[ -n "${{ inputs.verion }}" ]]; then
-          echo "::set-output name=artifact::$(python3 ${{ github.action_path }}/jprm/__init__.py plugin build ${{ inputs.path }} -o ${{ inputs.output }} -v ${{ inputs.verion }} --dotnet-configuration ${{ inputs.dotnet-config }} --dotnet-framework ${{ inputs.dotnet-target }})"
+          artifact="$(python3 ${{ github.action_path }}/jprm/__init__.py --verbosity=debug plugin build ${{ inputs.path }} -o ${{ inputs.output }} -v ${{ inputs.verion }} --dotnet-configuration ${{ inputs.dotnet-config }} --dotnet-framework ${{ inputs.dotnet-target }})"
         else
-          echo "::set-output name=artifact::$(python3 ${{ github.action_path }}/jprm/__init__.py plugin build ${{ inputs.path }} -o ${{ inputs.output }} --dotnet-configuration ${{ inputs.dotnet-config }} --dotnet-framework ${{ inputs.dotnet-target }})"
+          artifact="$(python3 ${{ github.action_path }}/jprm/__init__.py --verbosity=debug plugin build ${{ inputs.path }} -o ${{ inputs.output }} --dotnet-configuration ${{ inputs.dotnet-config }} --dotnet-framework ${{ inputs.dotnet-target }})"
         fi
+        echo "Artifact: ${artifact}"
+        echo "::set-output name=artifact::${artifact}"
         echo "::endgroup::"

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,64 @@
+name: 'jprm-build'
+description: 'Builds a Jellyfin plugin via Jellyfin Plugin Repository Manager'
+author: 'Odd Stråbø'
+
+branding:
+  icon: package
+  color: purple
+
+inputs:
+  path:
+    required: false
+    default: '.'
+    description: 'The path to the sources of the plugin solution (default: ".")'
+  output:
+    required: false
+    default: 'artifacts'
+    description: 'Path to dotnet build directory (default: artifacts)'
+  version:
+    required: false
+    default: ''
+    description: 'Overwrite the detected version of the plugin (default: "")'
+  dotnet-config:
+    required: false
+    default: 'Release'
+    description: 'The dotnet build configuration (default: Release)'
+  dotnet-target:
+    required: false
+    default: 'net5.0'
+    description: 'The dotnet target framework used for the plugin build (default: net5.0)'
+
+outputs:
+  artifact-dir:
+    description: 'Returns the "output" dir the plugin package got packaged to'
+    value: ${{ steps.out.outputs.artifact-dir }}
+
+runs:
+  using: composite
+  steps:
+    - name: Ensure ouput dir exists
+      shell: bash
+      run: |-
+        echo "::group::Preparing Environment"
+        mkdir -p ${{ inputs.output }}
+
+    - name: Setup JRPM Deps
+      shell: bash
+      run: |-
+        python3 -m pip install -r ${{ github.action_path }}/requirements.txt
+        echo "::endgroup::"
+
+    - name: Run JPRM build
+      shell: bash
+      run: |-
+        echo "::group::Building and Packaging"
+        if [[ -n "${{ inputs.verion }}" ]]; then
+          python3 ${{ github.action_path }}/jprm/__init__.py plugin build ${{ inputs.path }} -o ${{ inputs.output }} -v ${{ inputs.verion }} --dotnet-configuration ${{ inputs.dotnet-config }} --dotnet-framework ${{ inputs.dotnet-target }}
+        else
+          python3 ${{ github.action_path }}/jprm/__init__.py plugin build ${{ inputs.path }} -o ${{ inputs.output }} --dotnet-configuration ${{ inputs.dotnet-config }} --dotnet-framework ${{ inputs.dotnet-target }}
+        fi
+        echo "::endgroup::"
+
+    - id: out
+      shell: bash
+      run: echo "::set-output name=artifact-dir::${{ inputs.output }}"

--- a/action.yaml
+++ b/action.yaml
@@ -29,9 +29,9 @@ inputs:
     description: 'The dotnet target framework used for the plugin build (default: net5.0)'
 
 outputs:
-  artifact-dir:
-    description: 'Returns the "output" dir the plugin package got packaged to'
-    value: ${{ steps.out.outputs.artifact-dir }}
+  artifact:
+    description: 'Returns the built plugin zip'
+    value: ${{ steps.build.outputs.artifact }}
 
 runs:
   using: composite
@@ -48,17 +48,14 @@ runs:
         python3 -m pip install -r ${{ github.action_path }}/requirements.txt
         echo "::endgroup::"
 
-    - name: Run JPRM build
+    - id: build
+      name: Run JPRM build
       shell: bash
       run: |-
         echo "::group::Building and Packaging"
         if [[ -n "${{ inputs.verion }}" ]]; then
-          python3 ${{ github.action_path }}/jprm/__init__.py plugin build ${{ inputs.path }} -o ${{ inputs.output }} -v ${{ inputs.verion }} --dotnet-configuration ${{ inputs.dotnet-config }} --dotnet-framework ${{ inputs.dotnet-target }}
+          echo "::set-output name=artifact::$(python3 ${{ github.action_path }}/jprm/__init__.py plugin build ${{ inputs.path }} -o ${{ inputs.output }} -v ${{ inputs.verion }} --dotnet-configuration ${{ inputs.dotnet-config }} --dotnet-framework ${{ inputs.dotnet-target }})"
         else
-          python3 ${{ github.action_path }}/jprm/__init__.py plugin build ${{ inputs.path }} -o ${{ inputs.output }} --dotnet-configuration ${{ inputs.dotnet-config }} --dotnet-framework ${{ inputs.dotnet-target }}
+          echo "::set-output name=artifact::$(python3 ${{ github.action_path }}/jprm/__init__.py plugin build ${{ inputs.path }} -o ${{ inputs.output }} --dotnet-configuration ${{ inputs.dotnet-config }} --dotnet-framework ${{ inputs.dotnet-target }})"
         fi
         echo "::endgroup::"
-
-    - id: out
-      shell: bash
-      run: echo "::set-output name=artifact-dir::$(pwd)/${{ inputs.output }}"

--- a/action.yaml
+++ b/action.yaml
@@ -61,4 +61,4 @@ runs:
 
     - id: out
       shell: bash
-      run: echo "::set-output name=artifact-dir::${{ inputs.output }}"
+      run: echo "::set-output name=artifact-dir::$(pwd)/${{ inputs.output }}"


### PR DESCRIPTION
### Description

This PR aims to allow for this tool to be published as a GitHub Action.

Example use (once tagged 0.5.0, or any arbitrary tag, branch or git-sha that includes this metadata file):
```yaml
- name: Build Jellyfin Plugin
  uses:  oddstr13/jellyfin-plugin-repository-manager@v0.5.0
```

NOTE: for more public use publishing to the GH Marketplace seems like the best idea

### Changes

* add Composite Action metadata file

### Issues

* n/a

### Dependencies

* was based on the changes of #6 