### PR TITLE
Split build and publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build Python Package
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+
+      - name: Build package
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-artifact
+          retention-days: 30
+          if-no-files-found: error
+          path: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,17 @@
 name: Publish Python Package
 
 on:
-  push:
-    branches:
-      - master
-    tags:
-      - 'v*'
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      upload_url:
+        required: true
+        description: upload url of the release the assets need to get uploaded to
 
 jobs:
-  build:
+  build-publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -19,17 +22,11 @@ jobs:
         with:
           python-version: '3.9'
 
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel
+          pip install twine
 
       - name: Build package
         run: |
@@ -42,19 +39,6 @@ jobs:
           if-no-files-found: error
           path: dist
 
-  publish:
-    needs: build
-    runs-on: ubuntu-latest
-    environment: release
-    if: ${{ github.repository == 'oddstr13/jellyfin-plugin-repository-manager' && startsWith(github.ref, 'refs/tags/') }}
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: build-artifact
-
-      - name: Install Twine
-        run: pip install twine
-
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
@@ -62,12 +46,18 @@ jobs:
         run: |
           twine upload dist/*
 
-      - name: Set Version EnvVar
-        run: echo "JPRM_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      - name: Upload GitHub Release Artifacts
+        uses: shogo82148/actions-upload-release-asset@v1
+        if: ${{ github.event_name == 'release' }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: 'dist/*'
+          overwrite: true
 
       - name: Upload GitHub Release Artifacts
-        uses: ncipollo/release-action@v1
+        uses: shogo82148/actions-upload-release-asset@v1
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
-          allowUpdates: true
-          artifacts: 'dist/*'
-          tag: ${{ env.JPRM_VERSION }}
+          upload_url: ${{ github.event.inputs.upload_url }}
+          asset_path: 'dist/*'
+          overwrite: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
           asset_path: 'dist/*'
           overwrite: true
 
-      - name: Upload GitHub Release Artifacts
+      - name: Upload GitHub Release Artifacts (Manual trigger)
         uses: shogo82148/actions-upload-release-asset@v1
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:


### PR DESCRIPTION
### Description

This PR splits the build and publish GH Action workflows.
The publish workflow now uses a different trigger and adds a `manual overwrite` trigger if all things fail ;)

### Changes

* split build and publish workflow

### Issues

* n/a