### PR TITLE
Replace depreciated `set-output` command

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -73,5 +73,5 @@ runs:
         artifact="$(python3 ${{ github.action_path }}/jprm/__init__.py --verbosity=${{ inputs.verbosity }} plugin build ${{ inputs.path }} -o ${{ inputs.output }} ${PLUGIN_VERSION} --dotnet-configuration ${{ inputs.dotnet-config }} ${DOTNET_FRAMEWORK})"
         
         echo "Artifact: ${artifact}"
-        echo "::set-output name=artifact::${artifact}"
+        echo "artifact=${artifact}" >> $GITHUB_OUTPUT
         echo "::endgroup::"


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/