### PR TITLE
dotnet: Use PublishDir instead of --output

### DIFF
--- a/jprm/__init__.py
+++ b/jprm/__init__.py
@@ -373,7 +373,7 @@ def build_plugin(path, output=None, build_cfg=None, version=None, dotnet_config=
 
     build_command = "dotnet publish --nologo --no-restore" \
         " --configuration={dotnet_config} --framework={dotnet_framework}" \
-        " --output={output} -p:Version={version}"
+        " --property:PublishDir={output} -p:Version={version}"
 
     stdout, stderr, retcode = run_os_command(build_command.format(**params), cwd=path)
     if retcode:


### PR DESCRIPTION
It seems that the `-o/--output` option is giving an error since .NET 7.0.200 SDK. This error is happening in the GitHub action, as I reported here: https://github.com/oddstr13/jellyfin-plugin-repository-manager/issues/4#issuecomment-1437657654

I am quite new to .NET and C#, so please review this before merging.

Found the solution after looking at this blog post (https://steven-giesel.com/blogPost/554ba273-9594-4d55-aac2-1366e28954b3)

Similar issues:
- https://github.com/bUnit-dev/bUnit/issues/984
- https://github.com/microsoft/azure-pipelines-tasks/issues/17773