### PR TITLE
feat: allow extra arguments to be passed to dotnet publish command

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,10 @@ inputs:
     required: false
     default: ''
     description: 'Overwrite the detected dotnet target framework used for the plugin build (default: "")'
+  publish-extra-args:
+    required: false
+    default: '/maxcpucount:1'
+    description: 'Extra arguments to pass to dotnet publish (default: "")'
   verbosity:
     required: false
     default: 'debug'
@@ -70,7 +74,13 @@ runs:
           PLUGIN_VERSION=""
         fi
         
-        artifact="$(python3 ${{ github.action_path }}/jprm/__init__.py --verbosity=${{ inputs.verbosity }} plugin build ${{ inputs.path }} -o ${{ inputs.output }} ${PLUGIN_VERSION} --dotnet-configuration ${{ inputs.dotnet-config }} ${DOTNET_FRAMEWORK})"
+        if [[ -n "${{ inputs.publish-extra-args }}" ]]; then
+          PUBLISH_EXTRA_ARGS="--publish-extra-args ${{ inputs.publish-extra-args }}"
+        else
+          PUBLISH_EXTRA_ARGS=""
+        fi
+        
+        artifact="$(python3 ${{ github.action_path }}/jprm/__init__.py --verbosity=${{ inputs.verbosity }} plugin build ${{ inputs.path }} -o ${{ inputs.output }} ${PLUGIN_VERSION} --dotnet-configuration ${{ inputs.dotnet-config }} ${PUBLISH_EXTRA_ARGS} ${DOTNET_FRAMEWORK})"
         
         echo "Artifact: ${artifact}"
         echo "artifact=${artifact}" >> $GITHUB_OUTPUT

--- a/jprm/__init__.py
+++ b/jprm/__init__.py
@@ -306,7 +306,8 @@ class Version(object):
 ####################
 
 
-def build_plugin(path, output=None, build_cfg=None, version=None, dotnet_config='Release', dotnet_framework=None):
+def build_plugin(path, output=None, build_cfg=None, version=None, dotnet_config='Release', dotnet_framework=None,
+                 publish_extra_args=''):
     if build_cfg is None:
         build_cfg = get_config(path)
 
@@ -332,6 +333,7 @@ def build_plugin(path, output=None, build_cfg=None, version=None, dotnet_config=
         'dotnet_config': dotnet_config,
         'dotnet_framework': dotnet_framework,
         'output': output,
+        'publish_extra_args': publish_extra_args,
         'version': version,
     }
 
@@ -373,7 +375,7 @@ def build_plugin(path, output=None, build_cfg=None, version=None, dotnet_config=
 
     build_command = "dotnet publish --nologo --no-restore" \
         " --configuration={dotnet_config} --framework={dotnet_framework}" \
-        " -p:PublishDir={output} -p:Version={version}"
+        " -p:PublishDir={output} -p:Version={version} {publish_extra_args}"
 
     stdout, stderr, retcode = run_os_command(build_command.format(**params), cwd=path)
     if retcode:
@@ -806,9 +808,15 @@ def cli_plugin():
     default=None,
     help='Dotnet framework ({})'.format(DEFAULT_FRAMEWORK),
 )
-def cli_plugin_build(path, output, dotnet_configuration, dotnet_framework, version):
+@click.option('--publish-extra-args',
+    default='',
+    required=False,
+    help='Extra arguments to pass to dotnet publish',
+)
+def cli_plugin_build(path, output, dotnet_configuration, dotnet_framework, publish_extra_args, version):
     with tempfile.TemporaryDirectory() as bintemp:
-        build_plugin(path, output=bintemp, dotnet_config=dotnet_configuration, dotnet_framework=dotnet_framework, version=version)
+        build_plugin(path, output=bintemp, dotnet_config=dotnet_configuration, dotnet_framework=dotnet_framework,
+                     version=version, publish_extra_args=publish_extra_args)
         filename = package_plugin(path, version=version, binary_path=bintemp, output=output)
         click.echo(filename)
 


### PR DESCRIPTION
This PR adds the ability to pass extra args to the `dotnet publish` command.

I need to be able to do this after consistently facing an error due to MSBuild.

My error: https://github.com/LizardByte/Themerr-jellyfin/actions/runs/6203819809/job/16846153379#step:4:80

Additional references:
- https://github.com/dotnet/sdk/issues/2902
- https://github.com/dotnet/aspnetcore/issues/32219#issuecomment-1405048765