### PR TITLE
Add basic support for Directory.Build.props

### DIFF
--- a/jprm/__init__.py
+++ b/jprm/__init__.py
@@ -357,6 +357,10 @@ def build_plugin(path, output=None, build_cfg=None, version=None, dotnet_config=
                 projects.append(os.path.join(path, fn))
                 break
 
+    dbp_file = os.path.join(path, "Directory.Build.props")
+    if os.path.exists(dbp_file):
+        projects.append(dbp_file)
+
     for project in projects:
         set_project_version(project, version=version)
         set_project_framework(project, framework=dotnet_framework)


### PR DESCRIPTION
Only supports `Directory.Build.props` in base directory.

Should fix jellyfin/jellyfin#11238
Related to changes in jellyfin/jellyfin-meta-plugins#27
See also jellyfin/jellyfin-plugin-webhook#116 for PR adding this file.
See https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-directory?view=vs-2022 for documentation on the file.