### PR TITLE
feat: allow modifying changelog

### DIFF
--- a/Metadata.md
+++ b/Metadata.md
@@ -26,7 +26,7 @@ If there are multiple, the first file found is used.
 | `category` | string | ✔️ | `Authentication` / `Channels` / `General` / `Live TV` / `Metadata` / `Notifications` |
 | `owner` | string | ✔️ | Name of maintainer |
 | `artifacts` | list[string] | ✔️ | List of artifacts to include in the plugin zip |
-| `changelog` | string | ✔️ | Changes since last release |
+| `changelog` | string | ✔️ | Changes since last release. Can be overridden by `plugin build --changelog` or the action `changelog` input. |
 
 [DEFAULT_IMAGE_FILE]: https://github.com/oddstr13/jellyfin-plugin-repository-manager/blob/a2267abe5cbffe602dd8dd0d5c532ea32da7bafe/jprm/__init__.py#L35
 [DEFAULT_FRAMEWORK]: https://github.com/oddstr13/jellyfin-plugin-repository-manager/blob/a2267abe5cbffe602dd8dd0d5c532ea32da7bafe/jprm/__init__.py#L36

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,10 @@ inputs:
     required: false
     default: ''
     description: 'Overwrite the detected version of the plugin (default: "")'
+  changelog:
+    required: false
+    default: ''
+    description: 'Overwrite the detected changelog of the plugin, supports multiline values (default: "")'
   dotnet-config:
     required: false
     default: 'Release'
@@ -64,6 +68,8 @@ runs:
     - id: build
       name: Run JPRM build
       shell: bash
+      env:
+        JPRM_CHANGELOG: ${{ inputs.changelog }}
       run: |-
         echo "::group::Building and Packaging"
 
@@ -79,7 +85,13 @@ runs:
           PLUGIN_VERSION=""
         fi
 
-        artifact="$(python3 ${{ github.action_path }}/jprm/__init__.py --verbosity=${{ inputs.verbosity }} plugin build ${{ inputs.path }} -o ${{ inputs.output }} ${PLUGIN_VERSION} --dotnet-configuration ${{ inputs.dotnet-config }} --max-cpu-count ${{ inputs.max-cpu-count }} ${DOTNET_FRAMEWORK})"
+        if [[ -n "${JPRM_CHANGELOG}" ]]; then
+          PLUGIN_CHANGELOG="--changelog \"${JPRM_CHANGELOG}\""
+        else
+          PLUGIN_CHANGELOG=""
+        fi
+
+        artifact="$(python3 ${{ github.action_path }}/jprm/__init__.py --verbosity=${{ inputs.verbosity }} plugin build ${{ inputs.path }} -o ${{ inputs.output }} ${PLUGIN_VERSION} ${PLUGIN_CHANGELOG} --dotnet-configuration ${{ inputs.dotnet-config }} --max-cpu-count ${{ inputs.max-cpu-count }} ${DOTNET_FRAMEWORK})"
 
         echo "Artifact: ${artifact}"
         echo "artifact=${artifact}" >> $GITHUB_OUTPUT

--- a/action.yaml
+++ b/action.yaml
@@ -69,29 +69,37 @@ runs:
       name: Run JPRM build
       shell: bash
       env:
-        JPRM_CHANGELOG: ${{ inputs.changelog }}
+        GH_ACTION_PATH: ${{ github.action_path }}
+        INPUTS_CHANGELOG: ${{ inputs.changelog }}
+        INPUTS_DOTNET_CONFIG: ${{ inputs.dotnet-config }}
+        INPUTS_DOTNET_TARGET: ${{ inputs.dotnet-target }}
+        INPUTS_MAX_CPU_COUNT: ${{ inputs.max-cpu-count }}
+        INPUTS_OUTPUT: ${{ inputs.output }}
+        INPUTS_PATH: ${{ inputs.path }}
+        INPUTS_VERBOSITY: ${{ inputs.verbosity }}
+        INPUTS_VERSION: ${{ inputs.version }}
       run: |-
         echo "::group::Building and Packaging"
 
-        if [[ -n "${{ inputs.dotnet-target }}" ]]; then
-          DOTNET_FRAMEWORK="--dotnet-framework ${{ inputs.dotnet-target }}"
+        if [[ -n "${INPUTS_DOTNET_TARGET}" ]]; then
+          DOTNET_FRAMEWORK="--dotnet-framework ${INPUTS_DOTNET_TARGET}"
         else
           DOTNET_FRAMEWORK=""
         fi
 
-        if [[ -n "${{ inputs.version }}" ]]; then
-          PLUGIN_VERSION="-v ${{ inputs.version }}"
+        if [[ -n "${INPUTS_VERSION}" ]]; then
+          PLUGIN_VERSION="-v ${INPUTS_VERSION}"
         else
           PLUGIN_VERSION=""
         fi
 
-        if [[ -n "${JPRM_CHANGELOG}" ]]; then
-          PLUGIN_CHANGELOG="--changelog \"${JPRM_CHANGELOG}\""
+        if [[ -n "${INPUTS_CHANGELOG}" ]]; then
+          PLUGIN_CHANGELOG="--changelog \"${INPUTS_CHANGELOG}\""
         else
           PLUGIN_CHANGELOG=""
         fi
 
-        artifact="$(python3 ${{ github.action_path }}/jprm/__init__.py --verbosity=${{ inputs.verbosity }} plugin build ${{ inputs.path }} -o ${{ inputs.output }} ${PLUGIN_VERSION} ${PLUGIN_CHANGELOG} --dotnet-configuration ${{ inputs.dotnet-config }} --max-cpu-count ${{ inputs.max-cpu-count }} ${DOTNET_FRAMEWORK})"
+        artifact="$(python3 ${GH_ACTION_PATH}/jprm/__init__.py --verbosity=${INPUTS_VERBOSITY} plugin build ${INPUTS_PATH} -o ${INPUTS_OUTPUT} ${PLUGIN_VERSION} ${PLUGIN_CHANGELOG} --dotnet-configuration ${INPUTS_DOTNET_CONFIG} --max-cpu-count ${INPUTS_MAX_CPU_COUNT} ${DOTNET_FRAMEWORK})"
 
         echo "Artifact: ${artifact}"
         echo "artifact=${artifact}" >> $GITHUB_OUTPUT

--- a/jprm/__init__.py
+++ b/jprm/__init__.py
@@ -393,7 +393,7 @@ def build_plugin(path, output=None, build_cfg=None, version=None, dotnet_config=
     logger.info(stdout)
 
 
-def package_plugin(path, build_cfg=None, version=None, binary_path=None, output=None, bundle=False):
+def package_plugin(path, build_cfg=None, version=None, changelog=None, binary_path=None, output=None, bundle=False):
     if build_cfg is None:
         build_cfg = get_config(path)
 
@@ -449,7 +449,7 @@ def package_plugin(path, build_cfg=None, version=None, binary_path=None, output=
 
             build_cfg['image'] = image_name
 
-        meta = generate_metadata(build_cfg, version=version)
+        meta = generate_metadata(build_cfg, version=version, changelog=changelog)
         meta_tempfile = os.path.join(tempdir, JSON_METADATA_FILE)
         with open(meta_tempfile, 'w') as fh:
             json.dump(meta, fh, sort_keys=True, indent=4)
@@ -473,13 +473,16 @@ def package_plugin(path, build_cfg=None, version=None, binary_path=None, output=
     return output_path
 
 
-def generate_metadata(build_cfg, version=None, build_date=None):
+def generate_metadata(build_cfg, version=None, build_date=None, changelog=None):
 
     if version is None:
         version = build_cfg['version']
 
     if version is not None:
         version = Version(version).full()
+
+    if not changelog:
+        changelog = build_cfg['changelog']
 
     if build_date is None:
         build_date = datetime.datetime.utcnow().isoformat(timespec='seconds') + 'Z'
@@ -493,7 +496,7 @@ def generate_metadata(build_cfg, version=None, build_date=None):
         "category": build_cfg['category'],
         ########
         "version": version,
-        "changelog": build_cfg['changelog'],
+        "changelog": changelog,
         "targetAbi": build_cfg['targetAbi'],
 #        "sourceUrl": "{url}/{slug}/{slug}_{version}.zip".format(
 #            url=repo_url.rstrip('/'),
@@ -807,6 +810,10 @@ def cli_plugin():
     default=None,
     help='Plugin version',
 )
+@click.option('--changelog',
+    default=None,
+    help='Plugin changelog',
+)
 @click.option('--dotnet-configuration',
     default='Release',
     help='Dotnet configuration',
@@ -820,7 +827,7 @@ def cli_plugin():
     type=int,
     help='Max number of cores to use during build (1)',
 )
-def cli_plugin_build(path, output, dotnet_configuration, dotnet_framework, max_cpu_count, version):
+def cli_plugin_build(path, output, version, changelog, dotnet_configuration, dotnet_framework, max_cpu_count):
     build_cfg = get_config(path)
     if build_cfg is None:
         raise click.UsageError('No build config found in `{}`'.format(path))
@@ -828,7 +835,7 @@ def cli_plugin_build(path, output, dotnet_configuration, dotnet_framework, max_c
     with tempfile.TemporaryDirectory() as bintemp:
         build_plugin(path, output=bintemp, build_cfg=build_cfg, dotnet_config=dotnet_configuration, dotnet_framework=dotnet_framework,
                      version=version, max_cpu_count=max_cpu_count)
-        filename = package_plugin(path, build_cfg=build_cfg, version=version, binary_path=bintemp, output=output)
+        filename = package_plugin(path, build_cfg=build_cfg, version=version, changelog=changelog, binary_path=bintemp, output=output)
         click.echo(filename)
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,16 +1,16 @@
 from pathlib import Path
 import shutil
+import sys
 
 import pytest
+from click.testing import CliRunner
 import jprm
 
-from .test_utils import TEST_DATA_DIR
+from .test_utils import TEST_DATA_DIR, json_load
 
 
-@pytest.mark.datafiles(
-    TEST_DATA_DIR / "jprm.yaml",
-)
-def test_package_plugin(tmp_path_factory, datafiles: Path):
+@pytest.fixture
+def package_plugin_paths(tmp_path_factory, datafiles: Path):
     bindir: Path = tmp_path_factory.mktemp("bin")
     plugin: Path = tmp_path_factory.mktemp("plugin")
     artifacts: Path = tmp_path_factory.mktemp("artifacts")
@@ -18,6 +18,16 @@ def test_package_plugin(tmp_path_factory, datafiles: Path):
     (bindir / "dummy.dll").write_text("", "utf-8")
 
     shutil.copy(datafiles / "jprm.yaml", plugin)
+
+    return bindir, plugin, artifacts
+
+
+@pytest.mark.xfail(sys.platform.startswith("win"), reason="md5sum command unavailable on Windows")
+@pytest.mark.datafiles(
+    TEST_DATA_DIR / "jprm.yaml",
+)
+def test_package_plugin(package_plugin_paths):
+    bindir, plugin, artifacts = package_plugin_paths
 
     output_path = Path(
         jprm.package_plugin(
@@ -37,3 +47,83 @@ def test_package_plugin(tmp_path_factory, datafiles: Path):
 
     # res = jprm.run_os_command('unzip -t plugin-a_5.0.0.0.zip', cwd=str(artifacts))
     # assert res[2] == 0
+
+
+@pytest.mark.datafiles(
+    TEST_DATA_DIR / "jprm.yaml",
+)
+def test_package_plugin_changelog_override(package_plugin_paths):
+    bindir, plugin, artifacts = package_plugin_paths
+
+    changelog = "Line one\nLine two"
+    output_path = Path(
+        jprm.package_plugin(
+            str(plugin),
+            version="5.0",
+            changelog=changelog,
+            binary_path=str(bindir),
+            output=str(artifacts),
+        )
+    )
+
+    meta = json_load(Path(str(output_path) + ".meta.json"))
+    manifest = jprm.generate_plugin_manifest(str(output_path), meta=meta, md5="deadbeef")
+
+    assert meta["changelog"] == changelog
+    assert manifest["versions"][0]["changelog"] == changelog
+
+
+@pytest.mark.datafiles(
+    TEST_DATA_DIR / "jprm.yaml",
+)
+def test_package_plugin_empty_changelog_override_uses_config(package_plugin_paths):
+    bindir, plugin, artifacts = package_plugin_paths
+
+    output_path = Path(
+        jprm.package_plugin(
+            str(plugin),
+            version="5.0",
+            changelog="",
+            binary_path=str(bindir),
+            output=str(artifacts),
+        )
+    )
+
+    meta = json_load(Path(str(output_path) + ".meta.json"))
+
+    assert meta["changelog"] == "Initial Release\n"
+
+
+def test_cli_plugin_build_changelog_option(cli_runner: CliRunner, tmp_path: Path, monkeypatch):
+    build_cfg = {
+        "name": "Plugin A",
+        "guid": "f5ddc434-4b42-45d0-a049-8dda7f1ed30b",
+        "description": "Test plugin A",
+        "overview": "Test plugin A",
+        "owner": "Oddstr13",
+        "category": "Other",
+        "version": "1.0.0.0",  # NOSONAR(S1313) not an ip address
+        "changelog": "Initial Release\n",
+        "targetAbi": "10.8.0.0",  # NOSONAR(S1313) not an ip address
+        "artifacts": ["dummy.dll"],
+    }
+    captured = {}
+
+    monkeypatch.setattr(jprm, "get_config", lambda path: build_cfg)
+    monkeypatch.setattr(jprm, "build_plugin", lambda *args, **kwargs: None)
+
+    def fake_package_plugin(*args, **kwargs):
+        captured["changelog"] = kwargs.get("changelog")
+        return "artifact.zip"
+
+    monkeypatch.setattr(jprm, "package_plugin", fake_package_plugin)
+
+    changelog = "Line one\nLine two"
+    result = cli_runner.invoke(
+        jprm.cli,
+        ["plugin", "build", str(tmp_path), "--changelog", changelog],
+    )
+
+    assert result.exit_code == 0
+    assert captured["changelog"] == changelog
+    assert "artifact.zip" in result.stdout.splitlines(False)


### PR DESCRIPTION
This PR allows setting the changelog via inputs to jprm. The python and action were updated, as well as tests.

For tests, the existing test fails on windows so I marked it xfail in that situation. Also added a fixture to make it easier to reuse for different tests.

The second commit, fixes existing sonar issues and hardens the action against workflow injection attacks.